### PR TITLE
roxygen-syntax function documetion, warnings

### DIFF
--- a/R/nmh_get_neon_q_eval.R
+++ b/R/nmh_get_neon_q_eval.R
@@ -11,7 +11,10 @@ nmh_get_neon_q_eval <- function(dest_fp = 'data/raw/qaqc/', dest_fn = 'neon_q_ev
       dir.create(dest_fp, recursive = TRUE)
     }
 
-    # read in the discharge evaluation from Rhea et al. (in prep)
+    # read in the discharge evaluation from Rhea et al. 2023
+    # Data citation:
+    # Rhea, S. NEON Continuous Discharge Evaluation. HydroShare https://doi.org/10.4211/hs.03c52d47d66e40f4854da8397c7d9668 (2023).
+    # NOTE: must make sure function runs the same in case there have been any updates to data format in Hydroshare
     download.file(
       url = 'https://www.hydroshare.org/resource/03c52d47d66e40f4854da8397c7d9668/data/contents/neon_q_eval.csv',
       destfile = destfile

--- a/R/nmh_get_neon_q_sim.R
+++ b/R/nmh_get_neon_q_sim.R
@@ -1,8 +1,11 @@
-#' @export
 nmh_get_neon_q_sim <- function(
     gdrive = "MacroSheds",
     gdrive_filename = 'modeled_discharge_2022-10-13',
     file_ext = '.zip') {
+
+  # NOTE: this all must be replaced with most up to date public data source, a la
+  # Vlah et al. 2023 -- https://doi.org/10.5194/egusphere-2023-1178
+  # figshare: https://figshare.com/articles/dataset/Composite_discharge_series_for_each_NEON_stream_river_site_/23206592
   
   # first ----
   # download THE MOST RECENT NEON discharge simulations from Google Drive

--- a/R/nmh_get_scaling_coefs.R
+++ b/R/nmh_get_scaling_coefs.R
@@ -10,7 +10,9 @@ nmh_get_scaling_coefs <- function(dest_fp = 'data/raw/macrosheds/',
   }
   
   
-  # read in the discharge evaluation from Rhea et al. (in prep)
+  # NOTE: applies to this and other ismilar ufnction (1) only room in this town for one nmh_get_scaling_coef?
+  # and (2) should get this data from best available public src associated w publication, or, hosted on figshare with
+  # consent of original authors
   download.file(
     url = 'https://raw.githubusercontent.com/nmarzolf91/NEON-reaeration/master/data/derived/scaling_coefs/NEON_site_scaling_coefs.csv',
     destfile = destfile


### PR DESCRIPTION
@nmarzolf91 

- added documentation for nmh_get_neon_data following roxygen conventions (most crucial thing is good **param** descriptions)
- added some warnings (needs more)

NOTE: the Rhea et al 2023 and Vlah et al 2023 discharge data is kind of static? Rhea et al QAQC data is from Hydroshare, is that link the most current, include anything associated with the author corrections, slash is it being updated over time? The "simulated" discharge from Mike's work is from a google drive folder, which we definitely shouldn't export, and should also definitely change to retrieve from the[ publication's data hosted on figshare](https://figshare.com/articles/dataset/Composite_discharge_series_for_each_NEON_stream_river_site_/23206592?backTo=/collections/Composite_discharge_series_for_all_NEON_river_stream_sites_plus_figures_and_all_input_output_data_associated_with_Vlah_Ross_Rhea_Bernhardt_2023_Virtual_gauges_the_surprising_potential_to_reconstruct_continuous_streamflow_from_strategic_meas/6488065) I don't know if this will be updated for future years or not either.

 Necessary either way.

Documentation wise, this is a "rough draft," but with your review to ensure accuracy I think is more or less the minimum foundation for every function that has the @export tag (AKA, a user facing function)


